### PR TITLE
Fix sold out item removed on sale list of marketshop.

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -2319,11 +2319,6 @@ void clif_npc_market_open(map_session_data *sd, struct npc_data *nd) {
 			continue;
 		}
 
-		// Out of stock
-		if( item->qty == 0 ){
-			continue;
-		}
-
 		p->list[count].nameid = client_nameid( item->nameid );
 		p->list[count].type = itemtype( item->nameid );
 		p->list[count].price = item->value;


### PR DESCRIPTION
Fix sold out item removed on sale list of marketshop.
Now the item icon still exist in marketshop as gray icon.